### PR TITLE
add ignore_tags and non_splitting_tags options

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,12 @@ Here's a list of available language codes:
 | `NL`            | Dutch
 | `PL`            | Polish
 
-You can also use custom query parameters, like `tag_handling` or `split_sentences`:
+You can also use custom query parameters, like `tag_handling`, `split_sentences`, `non_splitting_tags` or `ignore_tags`:
 
 ```rb
 translation = DeepL.translate '<p>A sample</p>', 'EN', 'ES',
-                              tag_handling: 'xml', split_sentences: false
+                              tag_handling: 'xml', split_sentences: false,
+                              non_splitting_tags: 'h1', ignore_tags: 'code, pre'
 
 puts translation.text
 # => "<p>Una muestra</p>"
@@ -106,6 +107,8 @@ The following parameters will be automatically converted:
 | --------------------- | ---------------
 | `preserve_formatting` | Convertes `false` to `'0'` and `true` to `'1'`
 | `split_sentences`     | Convertes `false` to `'0'` and `true` to `'1'`
+| `non_splitting_tags`  | no conversion
+| `ignore_tags`         | no conversion
 
 ### Usage
 

--- a/lib/deepl/requests/translate.rb
+++ b/lib/deepl/requests/translate.rb
@@ -6,7 +6,7 @@ module DeepL
         preserve_formatting: { true => '1', false => '0' }
       }.freeze
 
-      attr_reader :text, :source_lang, :target_lang
+      attr_reader :text, :source_lang, :target_lang, :ignore_tags, :non_splitting_tags
 
       def initialize(api, text, source_lang, target_lang, options = {})
         super(api, options)

--- a/spec/fixtures/vcr_cassettes/translate_texts.yml
+++ b/spec/fixtures/vcr_cassettes/translate_texts.yml
@@ -211,4 +211,42 @@ http_interactions:
       string: '{"message":"Parameter ''target_lang'' not specified."}'
     http_version:
   recorded_at: Tue, 08 May 2018 16:31:37 GMT
+- request:
+    method: post
+    uri: https://api.deepl.com/v1/translate?auth_key=VALID_TOKEN
+    body:
+      encoding: US-ASCII
+      string: text=Welcome+and+%3Ccode%3EHello+great+World%3C%2Fcode%3E+Good+Morning%21&source_lang=EN&target_lang=ES
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 24 Jul 2018 12:42:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '119'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJ0cmFuc2xhdGlvbnMiOlt7ImRldGVjdGVkX3NvdXJjZV9sYW5ndWFnZSI6IkVOIiwidGV4dCI6IkJpZW52ZW5pZG8geSA8Y29kZT5IZWxsbyBncmVhdCBXb3JsZDwvY29kZT4gQnVlbm9zIGTDrWFzISJ9XX0=
+    http_version: 
+  recorded_at: Tue, 24 Jul 2018 12:42:18 GMT
 recorded_with: VCR 4.0.0

--- a/spec/requests/translate_spec.rb
+++ b/spec/requests/translate_spec.rb
@@ -14,6 +14,40 @@ describe DeepL::Requests::Translate do
       end
     end
 
+    context 'when using `non_splitting_tags` options' do
+      it 'should work with a nil values' do
+        request = DeepL::Requests::Translate.new(api, nil, nil, nil, non_splitting_tags: nil)
+        expect(request.options[:non_splitting_tags]).to eq(nil)
+      end
+
+      it 'should work with a blank list' do
+        request = DeepL::Requests::Translate.new(api, nil, nil, nil, non_splitting_tags: '')
+        expect(request.options[:non_splitting_tags]).to eq('')
+      end
+
+      it 'should work with a comma-separated list' do
+        request = DeepL::Requests::Translate.new(api, nil, nil, nil, non_splitting_tags: 'p, strong, span')
+        expect(request.options[:non_splitting_tags]).to eq('p, strong, span')
+      end
+    end
+
+    context 'when using `ignore_tags` options' do
+      it 'should work with a nil values' do
+        request = DeepL::Requests::Translate.new(api, nil, nil, nil, ignore_tags: nil)
+        expect(request.options[:ignore_tags]).to eq(nil)
+      end
+
+      it 'should work with a blank list' do
+        request = DeepL::Requests::Translate.new(api, nil, nil, nil, ignore_tags: '')
+        expect(request.options[:ignore_tags]).to eq('')
+      end
+
+      it 'should work with a comma-separated list' do
+        request = DeepL::Requests::Translate.new(api, nil, nil, nil, ignore_tags: 'p, strong, span')
+        expect(request.options[:ignore_tags]).to eq('p, strong, span')
+      end
+    end
+
     context 'when using `split_sentences` options' do
       it 'should convert `true` to `1`' do
         request = DeepL::Requests::Translate.new(api, nil, nil, nil, split_sentences: true)
@@ -97,6 +131,19 @@ describe DeepL::Requests::Translate do
 
         expect(text).to be_a(DeepL::Resources::Text)
         expect(text.text).to eq('<p>Texto de muestra</p>')
+        expect(text.detected_source_language).to eq('EN')
+      end
+    end
+
+    context 'When performing a valid request and passing a variable' do
+      let(:text) { 'Welcome and <code>Hello great World</code> Good Morning!' }
+      let(:ignore_tags) { 'code, span' }
+
+      it 'should return a text object' do
+        text = subject.request
+
+        expect(text).to be_a(DeepL::Resources::Text)
+        expect(text.text).to eq('Bienvenido y <code>Hello great World</code> Buenos días!')
         expect(text.detected_source_language).to eq('EN')
       end
     end


### PR DESCRIPTION
Hey @wikiti 👋

* DeepL Pro API:
  * https://www.deepl.com/api.html
* add `ignore_tags` option
* add `non_splitting_tags` option

---

I'm currently trying to get `deepl-rb` working with [`i18n-tasks`](https://github.com/glebm/i18n-tasks) to have feature parity with the google translate setup the `ignore_tags` option is important.

What do you think about this addition? I'm missing why my vcr response is `ASCII-8BIT` instead of `UTF-8` (and readable).