### PR TITLE
Update to api version 2

### DIFF
--- a/lib/deepl/requests/base.rb
+++ b/lib/deepl/requests/base.rb
@@ -1,7 +1,7 @@
 module DeepL
   module Requests
     class Base
-      API_VERSION = 'v1'.freeze
+      API_VERSION = 'v2'.freeze
 
       attr_reader :api, :response, :options
 


### PR DESCRIPTION
This uses the version 2 of the API.

The documentation states: "As of the current state, the two DeepL API versions differ only by the URL used to access the functionality."

Nothing else is needed. It is important to upgrade the api version as "version 1 of the DeepL API is not supported by the DeepL API plan available starting October 2018.". I was getting Unauthorized errors without this upgrade.