### PR TITLE
Fix error message when bad request body isn’t JSON

### DIFF
--- a/lib/deepl/exceptions/bad_request.rb
+++ b/lib/deepl/exceptions/bad_request.rb
@@ -3,6 +3,8 @@ module DeepL
     class BadRequest < RequestError
       def message
         JSON.parse(response.body)['message']
+      rescue JSON::ParserError
+        response.body
       end
     end
   end


### PR DESCRIPTION
I seem to have hit a `JSON::ParserError` triggered from inside the `DeepL::Exceptions::BadRequest` exception message. This change should help make the exception message more robust.