### PR TITLE
Add supports_formality attribute to Language resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,10 @@ puts DeepL.languages(type: :target).count
 ```
 
 All languages are also defined on the
-[official API documentation](https://www.deepl.com/docs-api/translating-text/)
+[official API documentation](https://www.deepl.com/docs-api/translating-text/).
+
+Note that target languages may include the `supports_formality` flag, which may be checked
+using the `DeepL::Resources::Language#supports_formality?`.
 
 ### Translate
 
@@ -154,6 +157,7 @@ You can capture and process exceptions that may be raised during API calls. Thes
 | `DeepL::Exceptions::LimitExceeded` | You've reached the API's call limit. |
 | `DeepL::Exceptions::QuotaExceeded` | You've reached the API's character limit. |
 | `DeepL::Exceptions::RequestError` | An unkown request error. Check `exception.response` and `exception.request` for more information. |
+| `DeepL::Exceptions::NotSupported` | The requested method or API endpoint is not supported. |
 
 An exampling of handling a generic exception:
 

--- a/lib/deepl.rb
+++ b/lib/deepl.rb
@@ -11,6 +11,7 @@ require 'deepl/exceptions/authorization_failed'
 require 'deepl/exceptions/bad_request'
 require 'deepl/exceptions/limit_exceeded'
 require 'deepl/exceptions/quota_exceeded'
+require 'deepl/exceptions/not_supported'
 
 # -- Requests
 require 'deepl/requests/base'

--- a/lib/deepl/configuration.rb
+++ b/lib/deepl/configuration.rb
@@ -18,7 +18,7 @@ module DeepL
     end
 
     def attributes
-      ATTRIBUTES.map { |attr| [attr, send(attr)] }.to_h
+      ATTRIBUTES.to_h { |attr| [attr, send(attr)] }
     end
 
     def ==(other)

--- a/lib/deepl/exceptions/not_supported.rb
+++ b/lib/deepl/exceptions/not_supported.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module DeepL
+  module Exceptions
+    class NotSupported < Error
+      def initialize(msg = 'The feature is not supported')
+        super
+      end
+    end
+  end
+end

--- a/lib/deepl/requests/languages.rb
+++ b/lib/deepl/requests/languages.rb
@@ -16,7 +16,9 @@ module DeepL
       def build_languages(request, response)
         data = JSON.parse(response.body)
         data.map do |language|
-          Resources::Language.new(language['language'], language['name'], request, response)
+          Resources::Language.new(language['language'], language['name'],
+                                  language.fetch('supports_formality', nil),
+                                  request, response)
         end
       end
 

--- a/lib/deepl/requests/languages.rb
+++ b/lib/deepl/requests/languages.rb
@@ -17,7 +17,7 @@ module DeepL
         data = JSON.parse(response.body)
         data.map do |language|
           Resources::Language.new(language['language'], language['name'],
-                                  language.fetch('supports_formality', nil),
+                                  language['supports_formality'],
                                   request, response)
         end
       end

--- a/lib/deepl/resources/language.rb
+++ b/lib/deepl/resources/language.rb
@@ -5,11 +5,17 @@ module DeepL
     class Language < Base
       attr_reader :code, :name
 
-      def initialize(code, name, *args)
+      def initialize(code, name, supports_formality = nil, *args)
         super(*args)
 
         @code = code
         @name = name
+        return if supports_formality.nil?
+
+        @supports_formality = supports_formality
+        define_singleton_method(:supports_formality) do
+          @supports_formality
+        end
       end
 
       def to_s

--- a/lib/deepl/resources/language.rb
+++ b/lib/deepl/resources/language.rb
@@ -5,21 +5,22 @@ module DeepL
     class Language < Base
       attr_reader :code, :name
 
-      def initialize(code, name, supports_formality = nil, *args)
+      def initialize(code, name, supports_formality, *args)
         super(*args)
 
         @code = code
         @name = name
-        return if supports_formality.nil?
-
         @supports_formality = supports_formality
-        define_singleton_method(:supports_formality) do
-          @supports_formality
-        end
       end
 
       def to_s
         "#{code} - #{name}"
+      end
+
+      def supports_formality?
+        return @supports_formality unless @supports_formality.nil?
+
+        raise Exceptions::NotSupported, 'Support formality is only available on target languages'
       end
     end
   end

--- a/spec/resources/language_spec.rb
+++ b/spec/resources/language_spec.rb
@@ -16,9 +16,8 @@ describe DeepL::Resources::Language do
         expect(subject.name).to eq('English')
       end
 
-      it 'should not include the supports formality attribute' do
-        expect(subject.respond_to?(:supports_formality)).to eq(false)
-        expect { subject.supports_formality }.to raise_error(NoMethodError)
+      it 'should not define the supports formality method' do
+        expect { subject.supports_formality? }.to raise_error(DeepL::Exceptions::NotSupported)
       end
     end
 
@@ -32,11 +31,11 @@ describe DeepL::Resources::Language do
       it 'should assign the attributes' do
         expect(subject.code).to eq('EN')
         expect(subject.name).to eq('English')
-        expect(subject.supports_formality).to eq(true)
       end
 
-      it 'should include the supports formality attribute' do
-        expect(subject.respond_to?(:supports_formality)).to eq(true)
+      it 'should include the supports formality method' do
+        expect { subject.supports_formality? }.not_to raise_error
+        expect(subject.supports_formality?).to be_truthy
       end
     end
   end

--- a/spec/resources/language_spec.rb
+++ b/spec/resources/language_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe DeepL::Resources::Language do
-  subject { described_class.new('EN', 'English', nil, nil) }
+  subject { described_class.new('EN', 'English', nil, nil, nil) }
 
   describe '#initialize' do
     context 'When building a basic object' do
@@ -14,6 +14,29 @@ describe DeepL::Resources::Language do
       it 'should assign the attributes' do
         expect(subject.code).to eq('EN')
         expect(subject.name).to eq('English')
+      end
+
+      it 'should not include the supports formality attribute' do
+        expect(subject.respond_to?(:supports_formality)).to eq(false)
+        expect { subject.supports_formality }.to raise_error(NoMethodError)
+      end
+    end
+
+    context 'when building a target language object' do
+      subject { described_class.new('EN', 'English', true, nil, nil) }
+
+      it 'should create a resource' do
+        expect(subject).to be_a(described_class)
+      end
+
+      it 'should assign the attributes' do
+        expect(subject.code).to eq('EN')
+        expect(subject.name).to eq('English')
+        expect(subject.supports_formality).to eq(true)
+      end
+
+      it 'should include the supports formality attribute' do
+        expect(subject.respond_to?(:supports_formality)).to eq(true)
       end
     end
   end


### PR DESCRIPTION
Hola @wikiti,

This PR adds the `supports_formality` attribute to a Language resource when listing the supported target languages (`type` parameter is set to `target`).

I've tried to mimic the DeepL API by not including the attribute in the language resource when `type` is set to `source`. Trying to access the `supports_formality` would raise `NoMethodError` which helps understanding that you're referencing a source language instead of a target language. Another way would be to have `SourceLanguage` and `TargetLanguage` resources, but probably a bit of an overkill for a single attribute.

My use case for this feature is when I'm translating text in dozens of languages and would like to use a different `formality` parameter per language (when available).

Thanks a lot for your work on this library! 👊 