### PR TITLE
splitting_tags support and fix tag array conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The following parameters will be automatically converted:
 | `preserve_formatting` | Converts `false` to `'0'` and `true` to `'1'`
 | `split_sentences`     | Converts `false` to `'0'` and `true` to `'1'`
 | `outline_detection`   | Converts `false` to `'0'` and `true` to `'1'`
+| `splitting_tags`      | Converts arrays to strings joining by commas
 | `non_splitting_tags`  | Converts arrays to strings joining by commas
 | `ignore_tags`         | Converts arrays to strings joining by commas
 | `formality`           | No conversion applied

--- a/lib/deepl/requests/translate.rb
+++ b/lib/deepl/requests/translate.rb
@@ -4,7 +4,7 @@ module DeepL
   module Requests
     class Translate < Base
       BOOLEAN_CONVERSION = { true => '1', false => '0' }.freeze
-      ARRAY_CONVERSION = ->(value) { value.is_a?(Array) ? value.join(', ') : value }.freeze
+      ARRAY_CONVERSION = ->(value) { value.is_a?(Array) ? value.join(',') : value }.freeze
       OPTIONS_CONVERSIONS = {
         split_sentences: BOOLEAN_CONVERSION,
         preserve_formatting: BOOLEAN_CONVERSION,

--- a/lib/deepl/requests/translate.rb
+++ b/lib/deepl/requests/translate.rb
@@ -9,11 +9,12 @@ module DeepL
         split_sentences: BOOLEAN_CONVERSION,
         preserve_formatting: BOOLEAN_CONVERSION,
         outline_detection: BOOLEAN_CONVERSION,
+        splitting_tags: ARRAY_CONVERSION,
         non_splitting_tags: ARRAY_CONVERSION,
         ignore_tags: ARRAY_CONVERSION
       }.freeze
 
-      attr_reader :text, :source_lang, :target_lang, :ignore_tags, :non_splitting_tags
+      attr_reader :text, :source_lang, :target_lang, :ignore_tags, :splitting_tags, :non_splitting_tags
 
       def initialize(api, text, source_lang, target_lang, options = {})
         super(api, options)

--- a/spec/requests/translate_spec.rb
+++ b/spec/requests/translate_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe DeepL::Requests::Translate do
-  let(:tags_str) { 'p, strong, span' }
+  let(:tags_str) { 'p,strong,span' }
   let(:tags_array) { %w[p strong span] }
 
   let(:api) { build_deepl_api }

--- a/spec/requests/translate_spec.rb
+++ b/spec/requests/translate_spec.rb
@@ -20,6 +20,33 @@ describe DeepL::Requests::Translate do
       end
     end
 
+    context 'when using `splitting_tags` options' do
+      it 'should work with a nil values' do
+        request = DeepL::Requests::Translate.new(api, nil, nil, nil, splitting_tags: nil)
+        expect(request.options[:splitting_tags]).to eq(nil)
+      end
+
+      it 'should work with a blank list' do
+        request = DeepL::Requests::Translate.new(api, nil, nil, nil, splitting_tags: '')
+        expect(request.options[:splitting_tags]).to eq('')
+      end
+
+      it 'should work with a comma-separated list' do
+        request = DeepL::Requests::Translate.new(api, nil, nil, nil, splitting_tags: tags_str)
+        expect(request.options[:splitting_tags]).to eq(tags_str)
+      end
+
+      it 'should convert arrays to strings' do
+        request = DeepL::Requests::Translate.new(api, nil, nil, nil, splitting_tags: tags_array)
+        expect(request.options[:splitting_tags]).to eq(tags_str)
+      end
+
+      it 'should leave strings as they are' do
+        request = DeepL::Requests::Translate.new(api, nil, nil, nil, splitting_tags: tags_str)
+        expect(request.options[:splitting_tags]).to eq(tags_str)
+      end
+    end
+
     context 'when using `non_splitting_tags` options' do
       it 'should work with a nil values' do
         request = DeepL::Requests::Translate.new(api, nil, nil, nil, non_splitting_tags: nil)


### PR DESCRIPTION
1. Add support for `splitting_tags` (see https://www.deepl.com/docs-api/handling-xml/)
2. From experimentation, the comma separated list of tags can not contain any spaces:

```ruby
html = "<p>私は<skip_b>アイスクリーム</skip_b>が好きです、そしてあなたは？</p>"

## Without space, tag ignored
options = {:tag_handling=>"xml", :split_sentences=>"nonewlines", :ignore_tags=>"skip,skip_b"}
result = DeepL.translate(html, 'JA', 'ZH', options)
#<DeepL::Resources::Text:0x00007fae98950788 @request=#<Net::HTTP::Post POST>, @response=#<Net::HTTPOK 200 OK readbody=true>, @text="<p>我喜欢<skip_b>アイスクリーム</skip_b>，而你呢？</p>", @detected_source_language="JA">

## With space, tag not ignored
options = {:tag_handling=>"xml", :split_sentences=>"nonewlines", :ignore_tags=>"skip, skip_b"}
result = DeepL.translate(html, 'JA', 'ZH', options)
#<DeepL::Resources::Text:0x00007fae9890be30 @request=#<Net::HTTP::Post POST>, @response=#<Net::HTTPOK 200 OK readbody=true>, @text="<p>我喜欢<skip_b>冰激凌</skip_b>，而你呢？</p>", @detected_source_language="JA">
```